### PR TITLE
Fix in readEncoderDiagnostics

### DIFF
--- a/Mechaduino/Mechaduino/Utils.cpp
+++ b/Mechaduino/Mechaduino/Utils.cpp
@@ -563,9 +563,9 @@ void readEncoderDiagnostics()           ////////////////////////////////////////
 
   if (angleTemp & (1 << 14))    SerialUSB.println("  Error occurred  ");
 
-  if (angleTemp & (1 << 11))    SerialUSB.println("  MAGH - magnetic field strength too high, set if AGC = 0x00. This indicates the non-linearity error may be increased");
+  if (angleTemp & (1 << 11))    SerialUSB.println("  MAGL - magnetic field strength too low, set if AGC = 0xFF. This indicates the output noise of the measured angle may be increased");
 
-  if (angleTemp & (1 << 10))    SerialUSB.println("  MAGL - magnetic field strength too low, set if AGC = 0xFF. This indicates the output noise of the measured angle may be increased");
+  if (angleTemp & (1 << 10))    SerialUSB.println("  MAGH - magnetic field strength too high, set if AGC = 0x00. This indicates the non-linearity error may be increased");
 
   if (angleTemp & (1 << 9))     SerialUSB.println("  COF - CORDIC overflow. This indicates the measured angle is not reliable");
 


### PR DESCRIPTION
The bits for `MAGH` and `MAGL` got mixed up in the `readEncoderDiagnostics` function. See Figure 21 of the as54047d datasheet.